### PR TITLE
Edit palette modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5440,6 +5440,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -11393,6 +11398,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-modal": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
+      "integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
+      "requires": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.5.10",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "react-router": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
@@ -13975,6 +13996,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node-sass": "^4.13.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-modal": "^3.11.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0"
   },

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,6 +15,9 @@ class App extends Component {
     this.state = {
       colors: [],
       projects: [],
+      paletteName: '',
+      projectName: '',
+      projectId: null,
       error: '',
       modalOpen: false,
     }
@@ -33,8 +36,19 @@ class App extends Component {
     }
   }
 
-  passPaletteColors = async (colors) => {
-    await this.setState({ colors: colors });
+  toggleModal = () => {
+    this.setState({
+      modalOpen: !this.state.modalOpen
+    })
+  }
+
+  passPaletteNameAndColors = (colors, project, paletteName) => {
+    this.setState({
+      colors: colors,
+      paletteName,
+      projectId: project.id,
+      projectName: project.name
+    });
   }
 
   render() {
@@ -69,8 +83,18 @@ class App extends Component {
         </ReactModal>       
         <Header />
         <main>
-          <Route exact path='/' render={() => <PaletteForm colors={this.state.colors} projects={projects} updateProjects={this.updateProjects} />}/>
-          <Route exact path='/projects' render={() => <ProjectsContainer projects={projects} passPaletteColors={this.passPaletteColors} />}/>
+          <Route exact path='/' render={() => <PaletteForm
+            colors={this.state.colors}
+            projects={projects}
+            updateProjects={this.updateProjects}
+            newPaletteName={this.state.paletteName}
+            oldProjectName={this.state.projectName}
+            selectedProjectId={this.state.projectId}
+          />} />
+          <Route exact path='/projects' render={() => <ProjectsContainer
+            projects={projects}
+            passPaletteNameAndColors={this.passPaletteNameAndColors}
+            toggleModal={this.toggleModal} />} />
         </main>
       </div>
     )

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Link } from 'react-router-dom';
+import ReactModal from 'react-modal';
 import Header from '../Header/Header';
 import { getProjects } from '../../utils/apiCalls';
 import PaletteForm from '../PaletteForm/PaletteForm';
@@ -12,8 +13,10 @@ class App extends Component {
   constructor() {
     super();
     this.state = {
+      colors: [],
       projects: [],
-      error: ''
+      error: '',
+      modalOpen: false,
     }
   }
 
@@ -30,14 +33,44 @@ class App extends Component {
     }
   }
 
+  passPaletteColors = async (colors) => {
+    await this.setState({ colors: colors });
+  }
+
   render() {
     const { projects, error } = this.state
     return (
       <div className='App'>
+        <ReactModal
+          ariaHideApp={false}
+          isOpen={this.state.modalOpen}
+          style={{
+            overlay: {
+              position: "fixed",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: "rgba(0, 0, 0, 0.85)",
+            },
+            content: {}
+          }}
+          contentLabel="Edit Palette"
+          className="EditPaletteModal"
+          overlayClassName="EditPaletteOverlay"
+        >
+          <h2>Would you like to edit this palette?</h2>
+          <button>
+            <Link to='/'>Yes</Link>
+          </button>
+          <button>
+            Cancel
+          </button>
+        </ReactModal>       
         <Header />
         <main>
-          <Route exact path='/' render={() => <PaletteForm projects={projects} updateProjects={this.updateProjects}/>}/>
-          <Route exact path='/projects' render={() => <ProjectsContainer projects={projects}/>}/>
+          <Route exact path='/' render={() => <PaletteForm colors={this.state.colors} projects={projects} updateProjects={this.updateProjects} />}/>
+          <Route exact path='/projects' render={() => <ProjectsContainer projects={projects} passPaletteColors={this.passPaletteColors} />}/>
         </main>
       </div>
     )

--- a/src/components/PaletteForm/PaletteForm.js
+++ b/src/components/PaletteForm/PaletteForm.js
@@ -3,10 +3,10 @@ import { addProject, addPalette } from '../../utils/apiCalls';
 import './PaletteForm.scss';
 
 class PaletteForm extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
-      colors: [],
+      colors: this.props.colors,
       newProjectName: '',
       newPaletteName: '',
       selectedProjectId: null,
@@ -15,14 +15,21 @@ class PaletteForm extends Component {
   }
 
   componentDidMount() {
-    let colors = [];
-    while (colors.length < 5) {
-      colors.push(this.getRandomColor())
+    this.colorCheck();
+  }
+
+  colorCheck = () => {
+    let { colors } = this.state;
+    console.log(colors)
+    if (colors.length < 5) {
+      while (colors.length < 5) {
+        colors.push(this.getRandomColor())
+      }
+      colors = colors.map((color, i) => {
+        return { [`color${i + 1}`]: color, isLocked: false }
+      })
+      this.setState({ colors })
     }
-    colors = colors.map((color, i) => {
-      return { [`color${i + 1}`]: color, isLocked: false }
-    })
-    this.setState({ colors })
   }
 
   getRandomColor() {
@@ -115,8 +122,10 @@ class PaletteForm extends Component {
   render() {
     const { projects } = this.props;
     const { colors } = this.state;
+    console.log(colors)
     const colorBtns = colors.map((color, i) => {
       const hexCode = color[`color${i + 1}`];
+      console.log(hexCode)
       return <button
             key={hexCode} 
             className='color' 

--- a/src/components/PaletteForm/PaletteForm.js
+++ b/src/components/PaletteForm/PaletteForm.js
@@ -8,8 +8,9 @@ class PaletteForm extends Component {
     this.state = {
       colors: this.props.colors,
       newProjectName: '',
-      newPaletteName: '',
-      selectedProjectId: null,
+      oldProjectName: this.props.oldProjectName || '',
+      newPaletteName: this.props.newPaletteName || '',
+      selectedProjectId: this.props.selectedProjectId || null,
       error: ''
     }
   }
@@ -20,7 +21,6 @@ class PaletteForm extends Component {
 
   colorCheck = () => {
     let { colors } = this.state;
-    console.log(colors)
     if (colors.length < 5) {
       while (colors.length < 5) {
         colors.push(this.getRandomColor())
@@ -69,7 +69,6 @@ class PaletteForm extends Component {
 
   handleDropDownChange = (e) => {
     // add error handling for not selected
-
     this.setState({ selectedProjectId: e.target.value});
   }
 
@@ -122,10 +121,8 @@ class PaletteForm extends Component {
   render() {
     const { projects } = this.props;
     const { colors } = this.state;
-    console.log(colors)
     const colorBtns = colors.map((color, i) => {
       const hexCode = color[`color${i + 1}`];
-      console.log(hexCode)
       return <button
             key={hexCode} 
             className='color' 
@@ -171,9 +168,9 @@ class PaletteForm extends Component {
           <form>
             <h3>Add this Palette to a Project</h3>
             <select
-              value={this.selectedProjectId}
-              defaultValue={'default'}
-              onChange={this.handleDropDownChange}
+              value={this.state.selectedProjectId}
+              defaultValue={this.state.oldProjectName || 'default'}
+              onChange={(event) => this.handleDropDownChange(event)}
             >
             <option value='default' disabled>Choose a Project ...</option>
             { projNames }

--- a/src/components/ProjectCard/ProjectCard.js
+++ b/src/components/ProjectCard/ProjectCard.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import './ProjectCard.scss';
 
-const ProjectCard = ({ project, passPaletteColors }) => {
-  // console.log(passPaletteColors);
+const ProjectCard = ({ project, passPaletteNameAndColors }) => {
   const { palettes } = project;
   const paletteCards = palettes.map(palette => {
     const { color1, color2, color3, color4, color5 } = palette;
@@ -35,7 +34,7 @@ const ProjectCard = ({ project, passPaletteColors }) => {
       <h4>{palette.name}</h4>
       <div
         className='five-colors'
-        onClick={() => passPaletteColors(paletteUnlocked)}
+        onClick={() => passPaletteNameAndColors(paletteUnlocked, { id: project.id, name: project.name }, palette.name)}
       >
         <div 
           className='palette-color'

--- a/src/components/ProjectCard/ProjectCard.js
+++ b/src/components/ProjectCard/ProjectCard.js
@@ -1,34 +1,61 @@
 import React from 'react';
 import './ProjectCard.scss';
 
-const ProjectCard = ({ project }) => {
+const ProjectCard = ({ project, passPaletteColors }) => {
+  // console.log(passPaletteColors);
   const { palettes } = project;
   const paletteCards = palettes.map(palette => {
+    const { color1, color2, color3, color4, color5 } = palette;
+    const paletteUnlocked = [
+      {
+        color1,
+        isLocked: false
+      },
+      {
+        color2,
+        isLocked: false
+      },
+      {
+        color3,
+        isLocked: false
+      },
+      {
+        color4,
+        isLocked: false
+      },
+      {
+        color5, 
+        isLocked: false
+      }  
+    ]
     return <section 
       key={palette.id}
       className='palette'
       >
       <h4>{palette.name}</h4>
-      <div className='five-colors'>
+      <div
+        className='five-colors'
+        onClick={() => passPaletteColors(paletteUnlocked)}
+      >
         <div 
           className='palette-color'
-          style={{backgroundColor: `${palette.color1}`}}
+          style={{backgroundColor: `${color1}`}}
         ></div>
         <div 
           className='palette-color'
-          style={{backgroundColor: `${palette.color2}`}}
+          style={{backgroundColor: `${color2}`}}
         ></div>
         <div 
           className='palette-color'
-          style={{backgroundColor: `${palette.color3}`}}
+          style={{backgroundColor: `${color3}`}}
         ></div>
         <div 
           className='palette-color'
-          style={{backgroundColor: `${palette.color4}`}}
+          style={{backgroundColor: `${color4}`}}
         ></div>
         <div 
           className='palette-color'
-          style={{backgroundColor: `${palette.color5}`}}
+          style={{backgroundColor: `${color5}`}}
         ></div>
       </div>
     </section>

--- a/src/components/ProjectsContainer/ProjectsContainer.js
+++ b/src/components/ProjectsContainer/ProjectsContainer.js
@@ -2,9 +2,9 @@ import React from 'react';
 import ProjectCard from '../ProjectCard/ProjectCard';
 import './ProjectsContainer.scss';
 
-const ProjectsContainer = ({ projects }) => {
+const ProjectsContainer = ({ projects, passPaletteColors }) => {
   const projCards = projects.map(project => {
-    return <ProjectCard key={project.id} project={project}/>
+    return <ProjectCard key={project.id} project={project} passPaletteColors={passPaletteColors}/>
   })
   return (
     <section className='projects'>

--- a/src/components/ProjectsContainer/ProjectsContainer.js
+++ b/src/components/ProjectsContainer/ProjectsContainer.js
@@ -2,9 +2,13 @@ import React from 'react';
 import ProjectCard from '../ProjectCard/ProjectCard';
 import './ProjectsContainer.scss';
 
-const ProjectsContainer = ({ projects, passPaletteColors }) => {
+const ProjectsContainer = ({ projects, passPaletteNameAndColors, toggleModal }) => {
   const projCards = projects.map(project => {
-    return <ProjectCard key={project.id} project={project} passPaletteColors={passPaletteColors}/>
+    return <ProjectCard
+      key={project.id}
+      project={project}
+      passPaletteNameAndColors={passPaletteNameAndColors}
+      toggleModal={toggleModal} />
   })
   return (
     <section className='projects'>


### PR DESCRIPTION
#### What's this PR do?
- Adds logic to include modal feedback for when a user wants to edit an existing palette
- Fills the "randomizing palette area" with the selected palette
- Fills input fields with the selected palette/project information
#### Where should the reviewer start?
- In the app component, and follow the prop drilling to the project card, then back up and over to the paletteForm
#### How should this be manually tested?
- Can be walked through currently
#### Any background context you want to provide?
- The modal is not currently styled
#### Screenshots (if appropriate):
<img width="936" alt="Screen Shot 2019-12-10 at 5 53 55 PM" src="https://user-images.githubusercontent.com/50842455/70581995-4707b600-1b76-11ea-9c83-12bc8669b20f.png">

#### Questions:
