### PR TITLE
Add ui feedback for editing project name

### DIFF
--- a/src/components/ProjectCard/ProjectCard.js
+++ b/src/components/ProjectCard/ProjectCard.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import './ProjectCard.scss';
 import close from '../../images/close-icon-svg-4.jpg'
-
 const ProjectCard = ({ project, handleModal, handleKeyPress, handleProjectDelete }) => {
   const { palettes } = project;
   const paletteCards = palettes.map(palette => {

--- a/src/components/ProjectCard/ProjectCard.scss
+++ b/src/components/ProjectCard/ProjectCard.scss
@@ -21,3 +21,10 @@
   height: 25px;
   width: 25px;
 }
+
+[contenteditable]:hover:after {
+  background: lightblue;
+  display: block;
+  content:'Click to Edit, Press "Enter" to save';
+  font-size: .75rem;
+}


### PR DESCRIPTION
#### What's this PR do?
- Adds UI feedback/directions for a User when they go to edit a project name
#### Where should the reviewer start?
- Project SCSS files holds most of the changes
#### How should this be manually tested?
- Hover over project names
#### Any background context you want to provide?
- 
#### Screenshots (if appropriate):
<img width="1006" alt="Screen Shot 2019-12-11 at 4 36 03 PM" src="https://user-images.githubusercontent.com/50842455/70671406-2bb1af00-1c39-11ea-9aab-08339317953b.png">

#### Questions:
